### PR TITLE
[WIP] Introduce the preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,31 @@
+name: Preview
+on: [workflow_dispatch, push, pull_request]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Use Node.js 14 LTS
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+
+      - name: Install Gulp
+        run: npm install -g gulp-cli
+
+      - name: Install other dependencies
+        run: npm install
+
+      - name: Generate website artifacts
+        run: gulp web
+
+      - name: Upload website artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: GitHub Pages
+          path: build/gh-pages/*
+          retention-days: 1

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1992,8 +1992,7 @@ gulp.task(
     "generic-legacy",
     "jsdoc",
     ghPagesPrepare,
-    "wintersmith",
-    ghPagesGit
+    "wintersmith"
   )
 );
 


### PR DESCRIPTION
This is a first try towards migrating this task away from the bots.

The Git logic should be split off from the website generation logic
since they are distinct tasks and the former cannot and should not run
on GitHub Actions.